### PR TITLE
feat: Integrate Toon format for LLM token optimization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,3 +333,5 @@ Examples (curl):
 ## Testing Notes
 
 - `node test/test-files.js` exercises the `/project/files` workflow (owner/RW uploads, RO restrictions, replacement + delete cleanup).
+- `pnpm test:subagent:mock` runs subagent tests with a mock AI server (no API keys required). The mock server simulates OpenAI-compatible chat/completions endpoints for testing without external API calls.
+- Mock AI server can be started standalone: `node test/mock-ai-server.js` (default port: 43333).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:share": "node test/test-share.js",
     "test:mcp-share": "node test/test-mcp-share.js",
     "test:subagent": "node test/test-subagent.js",
+    "test:subagent:mock": "MOCK_AI=true node test/test-subagent.js",
     "test:mcp": "node test/mcp.js",
     "test:files": "node test/test-files.js"
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@hello-pangea/dnd": "^18.0.1",
     "@mistralai/mistralai": "^1.10.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@toon-format/toon": "^0.8.0",
     "@uiw/react-markdown-preview": "^5.1.5",
     "@uiw/react-md-editor": "^4.0.8",
     "ai": "^5.0.39",

--- a/test/mock-ai-server.js
+++ b/test/mock-ai-server.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Mock AI API server for testing subagent functionality
+ * Simulates chat/completions endpoint for OpenAI-compatible APIs
+ *
+ * Usage: node test/mock-ai-server.js [port]
+ * Default port: 43333
+ */
+
+import express from 'express';
+import process from 'node:process';
+
+const PORT = process.env.MOCK_AI_PORT ? Number(process.env.MOCK_AI_PORT) : 43333;
+const app = express();
+
+app.use(express.json());
+
+// Mock chat completions endpoint
+app.post('/v1/chat/completions', (req, res) => {
+  const { messages, model } = req.body;
+
+  // Extract last user message
+  const lastUserMessage = messages?.filter(m => m.role === 'user').pop()?.content || '';
+
+  // Generate a mock response
+  const mockResponse = {
+    id: `chatcmpl-${Math.random().toString(36).slice(2, 15)}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: model || 'mock-model',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: `Mock AI response to: "${lastUserMessage.slice(0, 50)}...". This is a test response from the mock AI server. Task completed successfully.`
+        },
+        finish_reason: 'stop'
+      }
+    ],
+    usage: {
+      prompt_tokens: 20,
+      completion_tokens: 30,
+      total_tokens: 50
+    }
+  };
+
+  res.json(mockResponse);
+});
+
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', message: 'Mock AI server is running' });
+});
+
+// Root endpoint
+app.get('/', (req, res) => {
+  res.json({
+    message: 'Mock AI API Server',
+    endpoints: {
+      'POST /v1/chat/completions': 'Mock chat completions (OpenAI-compatible)',
+      'GET /health': 'Health check'
+    }
+  });
+});
+
+// Start server
+app.listen(PORT, '127.0.0.1', () => {
+  console.log(`Mock AI server listening on http://127.0.0.1:${PORT}`);
+  console.log(`Health check: http://127.0.0.1:${PORT}/health`);
+  console.log(`Chat completions: POST http://127.0.0.1:${PORT}/v1/chat/completions`);
+});
+
+// Handle shutdown gracefully
+process.on('SIGINT', () => {
+  console.log('\nShutting down mock AI server...');
+  process.exit(0);
+});


### PR DESCRIPTION
- Add @toon-format/toon package for token-efficient responses
- Convert all MCP tool responses from JSON to toon format
- Add fallback to JSON if toon encoding fails
- Update test suite to decode toon format responses
- Document toon format integration in AGENTS.md

This change reduces input token usage significantly while maintaining backward compatibility through test suite updates.

== Update ==

This is closed due to poor data format understanding from various models, maybe should try yaml next