### PR TITLE
feat: automatic task id generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,11 +159,10 @@ Expose these tools via MCP CallTool (Streamable HTTP). All tools operate by proj
 - `write_agent`: Write AGENTS.md `{ project_id, mode=full|patch|diff, content|patch, comment? }` (RW/owner). Patch/diff requires a unified diff. On success, responses include the updated `hash`.
 - `read_progress`: Read structured tasks `{ project_id, only? }` → `{ tasks, markdown }`. `only` filters by `pending | in_progress | completed | archived` (synonyms accepted). Archived tasks are excluded unless explicitly requested.
 - `progress_add`: Add structured tasks `{ project_id, item, comment? }`. Supports two formats:
-  - **Simplified (recommended for agents)**: `item` can be a string or array of strings (task descriptions only). The backend auto-generates unique task_ids and returns them in `generated_task_ids`.
+  - **Simplified (recommended)**: `item` can be a string or array of strings (task descriptions only). The backend auto-generates unique task_ids and returns them in `generated_task_ids`.
   - **Full format**: `item` is an array of task objects with explicit `task_id` (8-char lowercase a-z0-9), `task_info`, optional `parent_id`, `status`, `extra_note`.
   Duplicate `task_id` are skipped in `skipped`. Creates a new commit; response includes `hash` when items were added.
 - `progress_set_new_state`: Update tasks `{ project_id, match, state?, task_info?, parent_id?, extra_note?, comment? }`. Completing or archiving cascades to descendants. Lock rules apply (cannot edit locked items unless unlocking).
-- `generate_task_ids`: Generate N unique 8‑char IDs `{ count? }`. Note: When using `progress_add`, you can use the simplified format (string or array of strings) which auto-generates task_ids, removing the need to call this tool first.
 - `get_agents_md_best_practices_and_examples`: Best‑practices + examples from `example_agent_md.json`.
 - `list_project_logs`: List commit logs `{ project_id }` → `{ logs: [{ hash, message, modified_by, created_at }] }`. The `modified_by` field shows the username of who made each commit.
 - `revert_project`: Revert a project `{ project_id, hash }`. Participants can only revert to commits in their most recent consecutive sequence from the end (to prevent discarding others' work). On success, response includes `{ project_id, hash }`.
@@ -203,11 +202,11 @@ Structured tasks format:
 - `status` is one of `pending | in_progress | completed | archived` (synonyms accepted on input).
 - `parent_id` (optional) should reference the root task's `task_id` in the same project. This enables arbitrary-depth nesting; a child can itself be a root for deeper descendants.
 
-**Simplified task creation (recommended for agents):**
-- When calling `progress_add`, you can now provide just task descriptions (string or array of strings) instead of full task objects.
+**Simplified task creation (recommended):**
+- When calling `progress_add`, provide just task descriptions (string or array of strings) instead of full task objects.
 - The backend automatically generates unique 8-character task_ids and returns them in the response under `generated_task_ids`.
-- This eliminates the need to call `generate_task_ids` before creating tasks.
 - Example: `progress_add({ project_id: "abc123", item: ["Implement feature X", "Write tests", "Update docs"] })` will create three tasks with auto-generated IDs.
+- For single tasks: `progress_add({ project_id: "abc123", item: "Implement feature X" })`.
 
 Project selection: All task tools take a `name` (project name). The server resolves it to the correct internal `project_id`—you never need to provide `project_id` directly.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,9 +158,12 @@ Expose these tools via MCP CallTool (Streamable HTTP). All tools operate by proj
 - `read_agent`: Read AGENTS.md `{ project_id, lineNumbers? }` (RO/RW/owner).
 - `write_agent`: Write AGENTS.md `{ project_id, mode=full|patch|diff, content|patch, comment? }` (RW/owner). Patch/diff requires a unified diff. On success, responses include the updated `hash`.
 - `read_progress`: Read structured tasks `{ project_id, only? }` → `{ tasks, markdown }`. `only` filters by `pending | in_progress | completed | archived` (synonyms accepted). Archived tasks are excluded unless explicitly requested.
-- `progress_add`: Add structured tasks `{ project_id, item, comment? }`. Duplicate `task_id` are skipped in `skipped`. Creates a new commit; response includes `hash` when items were added.
+- `progress_add`: Add structured tasks `{ project_id, item, comment? }`. Supports two formats:
+  - **Simplified (recommended for agents)**: `item` can be a string or array of strings (task descriptions only). The backend auto-generates unique task_ids and returns them in `generated_task_ids`.
+  - **Full format**: `item` is an array of task objects with explicit `task_id` (8-char lowercase a-z0-9), `task_info`, optional `parent_id`, `status`, `extra_note`.
+  Duplicate `task_id` are skipped in `skipped`. Creates a new commit; response includes `hash` when items were added.
 - `progress_set_new_state`: Update tasks `{ project_id, match, state?, task_info?, parent_id?, extra_note?, comment? }`. Completing or archiving cascades to descendants. Lock rules apply (cannot edit locked items unless unlocking).
-- `generate_task_ids`: Generate N unique 8‑char IDs `{ count? }`.
+- `generate_task_ids`: Generate N unique 8‑char IDs `{ count? }`. Note: When using `progress_add`, you can use the simplified format (string or array of strings) which auto-generates task_ids, removing the need to call this tool first.
 - `get_agents_md_best_practices_and_examples`: Best‑practices + examples from `example_agent_md.json`.
 - `list_project_logs`: List commit logs `{ project_id }` → `{ logs: [{ hash, message, modified_by, created_at }] }`. The `modified_by` field shows the username of who made each commit.
 - `revert_project`: Revert a project `{ project_id, hash }`. Participants can only revert to commits in their most recent consecutive sequence from the end (to prevent discarding others' work). On success, response includes `{ project_id, hash }`.
@@ -198,7 +201,13 @@ Structured tasks format:
 - Task object: `{ task_id, task_info, parent_id?, status?, extra_note? }`.
 - `task_id` MUST be exactly 8 characters, lowercase `a-z` and `0-9` only (e.g., `abcd1234`). Invalid IDs are rejected.
 - `status` is one of `pending | in_progress | completed | archived` (synonyms accepted on input).
-- `parent_id` (optional) should reference the root task’s `task_id` in the same project. This enables arbitrary-depth nesting; a child can itself be a root for deeper descendants.
+- `parent_id` (optional) should reference the root task's `task_id` in the same project. This enables arbitrary-depth nesting; a child can itself be a root for deeper descendants.
+
+**Simplified task creation (recommended for agents):**
+- When calling `progress_add`, you can now provide just task descriptions (string or array of strings) instead of full task objects.
+- The backend automatically generates unique 8-character task_ids and returns them in the response under `generated_task_ids`.
+- This eliminates the need to call `generate_task_ids` before creating tasks.
+- Example: `progress_add({ project_id: "abc123", item: ["Implement feature X", "Write tests", "Update docs"] })` will create three tasks with auto-generated IDs.
 
 Project selection: All task tools take a `name` (project name). The server resolves it to the correct internal `project_id`—you never need to provide `project_id` directly.
 

--- a/index.js
+++ b/index.js
@@ -621,18 +621,8 @@ function buildMcpServer(userId, userName) {
         }
       },
       {
-        name: 'generate_task_ids',
-        description: 'Generate N random 8-character task IDs (lowercase a-z0-9) not used by this user across any project. Note: When using progress_add, you can now use the simplified format (string or array of strings) which auto-generates task_ids, removing the need to call this tool first.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            count: { type: 'number', minimum: 1, maximum: 200, default: 5 }
-          }
-        }
-      },
-      {
         name: 'progress_add',
-        description: 'Add one or more structured project-level tasks. Supports two formats: (1) Simplified: provide a string or array of strings (task descriptions only), and the backend auto-generates unique task_ids and returns them in the response. (2) Full: provide an array of task objects with explicit task_id (8-char lowercase a-z0-9), task_info; optional parent_id (root task_id), status (pending|in_progress|completed|archived), extra_note. The simplified format is recommended for agents as it removes the need to call generate_task_ids first. Optionally include a commit message via comment.' + agentsReminder,
+        description: 'Add one or more structured project-level tasks. Supports two formats: (1) Simplified (recommended): provide a string or array of strings (task descriptions only), and the backend auto-generates unique task_ids and returns them in the response. (2) Full: provide an array of task objects with explicit task_id (8-char lowercase a-z0-9), task_info; optional parent_id (root task_id), status (pending|in_progress|completed|archived), extra_note. Optionally include a commit message via comment.' + agentsReminder,
         inputSchema: {
           type: 'object',
           properties: {
@@ -1521,16 +1511,6 @@ function buildMcpServer(userId, userName) {
           const msg = String(err?.message || err || 'set_state failed');
           const code = /project not found/i.test(msg) ? 'project_not_found' : 'update_failed';
           return okText(JSON.stringify({ error: code, message: msg }));
-        }
-      }
-      case 'generate_task_ids': {
-        const { count } = args || {};
-        const n = Math.min(200, Math.max(1, Number.isFinite(count) ? Math.floor(count) : 5));
-        try {
-          const ids = await generateUniqueTaskIds(userId, n);
-          return okText(JSON.stringify({ ids }));
-        } catch (err) {
-          return okText(JSON.stringify({ error: 'generation_exhausted', message: String(err?.message || 'Unable to generate enough unique IDs') }));
         }
       }
       case 'list_project_logs': {

--- a/src/ui/components/TaskAddForm.jsx
+++ b/src/ui/components/TaskAddForm.jsx
@@ -20,12 +20,11 @@ export default function TaskAddForm({ projectId, onAdded, readOnly }) {
     if (readOnly) { toast.error('Read-only'); return; }
     setAdding(true);
     try {
-      const ids = await callTool(apiKey, 'generate_task_ids', { count: 1 });
-      const id = ids.ids?.[0];
       const taskInfo = text.trim();
-      const comment = `${shortUserFromKey(apiKey)} created task ${id}: ${taskInfo}`;
-      await callTool(apiKey, 'progress_add', { project_id: projectId, item: [{ task_id: id, task_info: taskInfo, status: 'pending' }], comment });
-      toast.success('Task added');
+      const comment = `${shortUserFromKey(apiKey)} created task: ${taskInfo}`;
+      const result = await callTool(apiKey, 'progress_add', { project_id: projectId, item: taskInfo, comment });
+      const generatedId = result.generated_task_ids?.[0] || 'unknown';
+      toast.success(`Task added (${generatedId})`);
       setText('');
       onAdded?.();
     } catch (err) {


### PR DESCRIPTION
- Add generateUniqueTaskIds() helper function for reusable UUID generation
- Modify progress_add to accept simplified formats:
  * Single string (task description)
  * Array of strings (task descriptions)
  * Array of objects (existing format, for UI compatibility)
- Auto-generate unique task_ids when simplified format is used
- Return generated_task_ids in response for agent reference
- Update progress_add and generate_task_ids tool descriptions
- Update AGENTS.md with simplified task creation documentation

UI workflow remains unchanged - continues to use generate_task_ids + progress_add with explicit task_ids. Agents can now use the simpler format without calling generate_task_ids first.